### PR TITLE
問題番号が同期するバグの修正

### DIFF
--- a/frontend/src/webview/src/screens/answer-screen/components/chat-panel/chats/QuestionMessage.tsx
+++ b/frontend/src/webview/src/screens/answer-screen/components/chat-panel/chats/QuestionMessage.tsx
@@ -10,7 +10,7 @@ interface Props {
 }
 
 const QuestionMessage: React.FC<Props> = ({ msg }) => {
-  const { currentCharacter, questionId } = useAnswerContext();
+  const { currentCharacter } = useAnswerContext();
   return (
     <Box sx={{ my: 2 }}>
       <Box sx={{ display: "flex", gap: "5%", alignItems: "center", mt: 1 }}>
@@ -28,7 +28,7 @@ const QuestionMessage: React.FC<Props> = ({ msg }) => {
           }}
         >
           <Typography sx={{ fontSize: 20, fontWeight: "bold" }}>
-            {questionId} / {currentCharacter.totalQuestion}
+            {msg.questionId} of {currentCharacter.totalQuestion}
           </Typography>
         </Box>
       </Box>

--- a/frontend/src/webview/src/screens/answer-screen/context/AnswerContextProvider.tsx
+++ b/frontend/src/webview/src/screens/answer-screen/context/AnswerContextProvider.tsx
@@ -25,7 +25,7 @@ export const AnswerContextProvider: React.FC<AnswerContextProviderProps> = ({
   firstlQuestion,
 }) => {
   const [chatHistory, setChatHistory] = useState<ChatMessage[]>([
-    { type: "question", text: firstlQuestion },
+    { type: "question", text: firstlQuestion, questionId: 1 },
   ]);
   const [chatInput, setChatInput] = useState<string>("");
   const [questionId, setQuestionId] = useState<number>(1);
@@ -46,7 +46,7 @@ export const AnswerContextProvider: React.FC<AnswerContextProviderProps> = ({
       if (payload.continueQuestion) {
         setChatHistory((prev) => [
           ...prev,
-          { type: "question", text: payload.response },
+          { type: "question", text: payload.response, questionId: payload.questionId },
         ]);
         setDisplayEnterBox(true);
       } else {
@@ -146,7 +146,7 @@ export const AnswerContextProvider: React.FC<AnswerContextProviderProps> = ({
           stopThinking();
           setChatHistory((prev) => [
             ...prev,
-            { type: "question", text: msg.payload.question },
+            { type: "question", text: msg.payload.question, questionId: msg.payload.questionId },
           ]);
           setQuestionId(msg.payload.questionId);
           setButtonDisplay("スキップ");

--- a/frontend/src/webview/src/types/chat-message.d.ts
+++ b/frontend/src/webview/src/types/chat-message.d.ts
@@ -2,6 +2,7 @@ export type ChatMessage =
   | {
       type: "question";
       text: string;
+      questionId: number;
     }
   | {
       type: "answer";


### PR DESCRIPTION
## Issue
- close #97 

## やったこと
・chatでquestionIdがページ全体に渡されるものを使っていたので，chatごとにquestionIdを持たせてそれを使うようにした

チャットの内容は適当なので気にしないでください
## 動作確認

https://github.com/user-attachments/assets/e09f7a85-1b0a-429c-96bf-8efdd5a63363

