### PR TITLE
max_scoreをtotal_questionに変える

### DIFF
--- a/backend/app/domain/entities/interview_question.py
+++ b/backend/app/domain/entities/interview_question.py
@@ -11,7 +11,7 @@ class InterviewQuestion:
         interview_id (str): 面接ID
         question_id (str): 質問ID
         difficulty (Difficulty): 難易度
-        max_score (int): 最大スコア
+        total_question (int): 質問数
         score (int): スコア
         chat_history (ChatHistory): 会話履歴
     """
@@ -29,8 +29,8 @@ class InterviewQuestion:
         return self._difficulty
 
     @property
-    def max_score(self) -> int:
-        return self._max_score
+    def total_question(self) -> int:
+        return self._total_question
 
     @property
     def score(self) -> int:
@@ -42,9 +42,10 @@ class InterviewQuestion:
 
     @score.setter
     def score(self, value: int):
-        if value < 0 or value > self.max_score:
+        max_score = 100 // self.total_question
+        if value < 0 or max_score < value:
             raise ValueError(
-                f"スコアは0から最大スコア({self.max_score})までの間でなければなりません"
+                f"スコアは0から最大スコア({max_score})までの間でなければなりません"
             )
 
         self._score = value
@@ -54,7 +55,7 @@ class InterviewQuestion:
         interview_id: str,
         question_id: str,
         difficulty: Difficulty,
-        max_score: int,
+        total_question: int,
         chat_history: ChatHistory,
         score: int = 0,
     ):
@@ -64,14 +65,14 @@ class InterviewQuestion:
             interview_id (str): 面接ID
             question_id (str): 質問ID
             difficulty (Difficulty): 難易度
-            max_score (int): 最大スコア
+            total_question (int): 質問数
             chat_history (ChatHistory): 会話履歴
             score (int): スコア
         """
         self._interview_id = interview_id
         self._question_id = question_id
         self._difficulty = difficulty
-        self._max_score = max_score
+        self._total_question = total_question
         self._chat_history = chat_history
         self._score = score
 
@@ -89,7 +90,7 @@ class InterviewQuestion:
             "interview_id": self._interview_id,
             "question_id": self._question_id,
             "difficulty": self._difficulty.value,
-            "max_score": self._max_score,
+            "total_question": self._total_question,
             "score": self._score,
             "chat_history": self._chat_history.to_dict(),
         }
@@ -103,8 +104,8 @@ class InterviewQuestion:
             raise ValueError("question_idが存在しません")
         if "difficulty" not in data:
             raise ValueError("difficultyが存在しません")
-        if "max_score" not in data:
-            raise ValueError("max_scoreが存在しません")
+        if "total_question" not in data:
+            raise ValueError("total_questionが存在しません")
         if "score" not in data:
             raise ValueError("scoreが存在しません")
         if "chat_history" not in data:
@@ -114,7 +115,7 @@ class InterviewQuestion:
             interview_id=data["interview_id"],
             question_id=data["question_id"],
             difficulty=Difficulty(data["difficulty"]),
-            max_score=data["max_score"],
+            total_question=data["total_question"],
             score=data["score"],
             chat_history=ChatHistory.from_dict(data["chat_history"]),
         )

--- a/backend/app/domain/llm_clients/llm_client.py
+++ b/backend/app/domain/llm_clients/llm_client.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 
+from app.domain.entities.chat_history import ChatHistory
 from app.domain.entities.difficulty import Difficulty
 from app.domain.entities.evaluation_result import QuestionEvaluationResult
 from app.domain.entities.interview_question import InterviewQuestion
@@ -75,11 +76,16 @@ class LLMClient(ABC):
         pass
 
     @abstractmethod
-    def generate_general_review(self, question: InterviewQuestion) -> str:
+    def generate_general_review(
+        self,
+        difficulty: Difficulty,
+        chat_histories: list[ChatHistory],
+    ) -> str:
         """総評を生成する
 
         Args:
-            question (InterviewQuestion): 質問の情報
+            difficulty (Difficulty): 難易度
+            chat_histories (list[ChatHistory]): 会話履歴のリスト
 
         Returns:
             str: 総評文

--- a/backend/app/infrastructure/llm_clients/google/llm_client.py
+++ b/backend/app/infrastructure/llm_clients/google/llm_client.py
@@ -240,8 +240,9 @@ class GoogleLLMClient(LLMClient):
 
         contents = self.make_chat_history_contents(question.chat_history)
 
+        max_score = 100 // question.total_question
         feedback_prompt = PromptService.make_feedback_prompt(
-            question.max_score,
+            max_score,
             source_code,
         )
         contents.append(
@@ -288,8 +289,9 @@ class GoogleLLMClient(LLMClient):
 
         contents = self.make_chat_history_contents(question.chat_history)
 
+        max_score = 100 // question.total_question
         deep_question_prompt = PromptService.make_deep_question_prompt(
-            question.max_score,
+            max_score,
             source_code,
         )
         contents.append(
@@ -315,24 +317,26 @@ class GoogleLLMClient(LLMClient):
 
     def generate_general_review(
         self,
-        question: InterviewQuestion,
+        difficulty: Difficulty,
+        chat_histories: list[ChatHistory],
     ) -> str:
         """総評を生成する
 
         Args:
-            question (InterviewQuestion): 質問の情報
+            difficulty (Difficulty): 難易度
+            chat_histories (list[ChatHistory]): 会話履歴のリスト
 
         Returns:
             str: 総評
         """
-        character_prompt = PromptService.get_character_prompt(question.difficulty)
+        character_prompt = PromptService.get_character_prompt(difficulty)
         content_config = self.make_content_config(
             character_prompt=character_prompt,
             response_mime_type="text/plain",
         )
 
         # fmt: off
-        general_review_prompt = PromptService.make_general_review_prompt(question.chat_history)
+        general_review_prompt = PromptService.make_general_review_prompt(chat_histories)
         contents = [
             types.Content(
                 role="user", parts=[types.Part.from_text(text=general_review_prompt)]

--- a/backend/app/infrastructure/llm_clients/prompt_service.py
+++ b/backend/app/infrastructure/llm_clients/prompt_service.py
@@ -93,25 +93,6 @@ class PromptService:
         )
 
     @classmethod
-    def make_general_review_prompt(cls, chat_history: ChatHistory) -> str:
-        """総評を生成するプロンプトを取得する
-
-        Args:
-            chat_history (ChatHistory): チャット履歴
-
-        Returns:
-            str: 総評を生成するプロンプト
-        """
-        file_path = cls.user_prompt_dir_path / "general_review.txt"
-
-        with open(file_path, "r", encoding="utf-8") as f:
-            prompt_template = f.read()
-
-        return prompt_template.format(
-            chat_histories=json.dumps(chat_history.to_dict()),
-        )
-
-    @classmethod
     def make_deep_question_prompt(cls, max_score: int, source_code: SourceCode) -> str:
         """深掘りの質問を生成するプロンプトを取得する
 
@@ -130,4 +111,25 @@ class PromptService:
         return prompt_template.format(
             max_score=max_score,
             source_code=source_code.format(),
+        )
+
+    @classmethod
+    def make_general_review_prompt(cls, chat_histories: list[ChatHistory]) -> str:
+        """総評を生成するプロンプトを取得する
+
+        Args:
+            chat_history (ChatHistory): チャット履歴
+
+        Returns:
+            str: 総評を生成するプロンプト
+        """
+        file_path = cls.user_prompt_dir_path / "general_review.txt"
+
+        with open(file_path, "r", encoding="utf-8") as f:
+            prompt_template = f.read()
+
+        return prompt_template.format(
+            chat_histories=json.dumps(
+                [chat_history.to_dict() for chat_history in chat_histories]
+            ),
         )

--- a/backend/app/usecase/usecases/setup_interview_usecase.py
+++ b/backend/app/usecase/usecases/setup_interview_usecase.py
@@ -53,14 +53,12 @@ class SetUpInterviewUseCase:
             request.total_question,
         )
 
-        max_score = 100 // request.total_question
-
         interview_questions = [
             InterviewQuestion(
                 interview_id=interview_id,
                 question_id=str(i + 1),
                 difficulty=request.difficulty,
-                max_score=max_score,
+                total_question=request.total_question,
                 chat_history=ChatHistory([ChatMessage(role="model", message=question)]),
             )
             for i, question in enumerate(questions)

--- a/backend/tests/usecase/usecases/test_get_feedback_usecase.py
+++ b/backend/tests/usecase/usecases/test_get_feedback_usecase.py
@@ -19,7 +19,7 @@ source_code = SourceCode(
         "main.py": "print('Hello, World!')",
     }
 )
-max_score = 25
+total_question = 4
 feedback_score = 20
 feedback_comment = "良いコードです"
 
@@ -50,7 +50,7 @@ def test_execute_success(
         interview_id=interview_id,
         question_id=question_id,
         difficulty=Difficulty.normal,
-        max_score=max_score,
+        total_question=total_question,
         chat_history=ChatHistory(),
         score=0,
     )
@@ -145,7 +145,7 @@ def test_execute_failure_when_source_code_not_found(
         interview_id=interview_id,
         question_id=question_id,
         difficulty=Difficulty.normal,
-        max_score=max_score,
+        total_question=total_question,
         chat_history=ChatHistory(),
         score=0,
     )
@@ -184,7 +184,7 @@ def test_execute_failure_when_feedback_generation_fails(
         interview_id=interview_id,
         question_id=question_id,
         difficulty=Difficulty.normal,
-        max_score=max_score,
+        total_question=total_question,
         chat_history=ChatHistory(),
         score=0,
     )
@@ -224,12 +224,13 @@ def test_execute_failure_when_score_exceeds_max_score(
         interview_id=interview_id,
         question_id=question_id,
         difficulty=Difficulty.normal,
-        max_score=max_score,
+        total_question=total_question,
         chat_history=ChatHistory(),
         score=0,
     )
     mock_interview_repository.get_question.return_value = question
     mock_source_code_repository.get_source_code.return_value = source_code
+    max_score = 100 // total_question
     mock_llm_client.generate_feedback.return_value = InterviewFeedback(
         score=max_score + 1,  # max_scoreより大きいスコア
         comment=feedback_comment,
@@ -267,7 +268,7 @@ def test_execute_failure_when_update_question_fails(
         interview_id=interview_id,
         question_id=question_id,
         difficulty=Difficulty.normal,
-        max_score=max_score,
+        total_question=total_question,
         chat_history=ChatHistory(),
         score=0,
     )

--- a/backend/tests/usecase/usecases/test_get_question_usecase.py
+++ b/backend/tests/usecase/usecases/test_get_question_usecase.py
@@ -28,7 +28,7 @@ def test_execute_success(
         interview_id=interview_id,
         question_id=question_id,
         difficulty=Difficulty.normal,
-        max_score=25,
+        total_question=4,
         chat_history=chat_history,
         score=0,
     )

--- a/backend/tests/usecase/usecases/test_set_up_interview_usecase.py
+++ b/backend/tests/usecase/usecases/test_set_up_interview_usecase.py
@@ -12,8 +12,8 @@ from app.usecase.usecases.setup_interview_usecase import SetUpInterviewUseCase
 # テストデータ
 source_code = b"test_zip_content"
 difficulty = Difficulty.normal
-total_question = 3
-questions = ["質問1", "質問2", "質問3"]
+total_question = 4
+questions = ["質問1", "質問2", "質問3", "質問4"]
 extracted_code = SourceCode(
     {
         "main.py": "print('Hello, World!')",
@@ -80,7 +80,7 @@ def test_execute_success(
         assert question.interview_id == response.interview_id
         assert question.question_id == str(i + 1)
         assert question.difficulty == difficulty
-        assert question.max_score == 100 // total_question
+        assert question.total_question == total_question
         assert question.score == 0
 
         assert isinstance(question.chat_history, ChatHistory)


### PR DESCRIPTION
## Issue

- Close #133 

## やったこと

- タイトル参照
- LLMクライアントの総評を生成するメソッドのインタフェースを変更した

## 動作確認

```sh
======================================================================= test session starts ========================================================================
platform darwin -- Python 3.12.0, pytest-8.4.0, pluggy-1.6.0
rootdir: /Users/shunsei/workspace/project/hackathon/repo-interviewer/backend
configfile: pyproject.toml
plugins: anyio-4.9.0
collected 14 items                                                                                                                                                 

domain/entities/test_chat_history.py .                                                                                                                       [  7%]
usecase/usecases/test_get_feedback_usecase.py ......                                                                                                         [ 50%]
usecase/usecases/test_get_question_usecase.py ...                                                                                                            [ 71%]
usecase/usecases/test_set_up_interview_usecase.py ....                                                                                                       [100%]

======================================================================== 14 passed in 0.32s ========================================================================
```