### PR TITLE
総評を生成するユースケースを実装した

### DIFF
--- a/backend/app/domain/llm_clients/llm_client.py
+++ b/backend/app/domain/llm_clients/llm_client.py
@@ -88,6 +88,6 @@ class LLMClient(ABC):
             chat_histories (list[ChatHistory]): 会話履歴のリスト
 
         Returns:
-            str: 総評文
+            str: 総評
         """
         pass

--- a/backend/app/domain/repositories/interview_repository.py
+++ b/backend/app/domain/repositories/interview_repository.py
@@ -47,3 +47,15 @@ class InterviewRepository(ABC):
             question (InterviewQuestion): 更新後の質問の情報
         """
         pass
+
+    @abstractmethod
+    def get_all_questions(
+        self,
+        interview_id: str,
+    ) -> list[InterviewQuestion]:
+        """面接の質問をすべて取得する
+
+        Args:
+            interview_id (str): 面接ID
+        """
+        pass

--- a/backend/app/infrastructure/repositories/redis/interview_repository.py
+++ b/backend/app/infrastructure/repositories/redis/interview_repository.py
@@ -89,3 +89,26 @@ class RedisInterviewRepository(InterviewRepository):
         )
 
         return question
+
+    def get_all_questions(
+        self,
+        interview_id: str,
+    ) -> list[InterviewQuestion]:
+        """面接の質問をすべて取得する
+
+        Args:
+            interview_id (str): 面接ID
+
+        Returns:
+            list[InterviewQuestion]: 面接の質問のリスト
+        """
+        redis_client = self.get_redis_client()
+        keys = redis_client.scan(match=f"{interview_id}-*")
+
+        questions = redis_client.mget(keys[1])
+        if questions is None:
+            return []
+
+        return [
+            InterviewQuestion.from_dict(json.loads(question)) for question in questions
+        ]

--- a/backend/app/schemas/interview_schema.py
+++ b/backend/app/schemas/interview_schema.py
@@ -44,4 +44,4 @@ class GetInterviewResultRequest(BaseModel):
 class GetInterviewResultResponse(BaseModel):
     interview_id: str
     scores: list[int]
-    general_review: str
+    overall_review: str

--- a/backend/app/schemas/interview_schema.py
+++ b/backend/app/schemas/interview_schema.py
@@ -35,3 +35,13 @@ class GetQuestionResponse(BaseModel):
     interview_id: str
     question_id: str
     question: str
+
+
+class GetInterviewResultRequest(BaseModel):
+    interview_id: str
+
+
+class GetInterviewResultResponse(BaseModel):
+    interview_id: str
+    scores: list[int]
+    general_review: str

--- a/backend/app/usecase/usecases/get_interview_result_usecase.py
+++ b/backend/app/usecase/usecases/get_interview_result_usecase.py
@@ -14,10 +14,24 @@ class GetInterviewResultUseCase:
         interview_repository: InterviewRepository,
         llm_client: LLMClient,
     ):
+        """コンストラクタ
+
+        Args:
+            interview_repository (InterviewRepository): 面接リポジトリ
+            llm_client (LLMClient): LLMクライアント
+        """
         self.interview_repository = interview_repository
         self.llm_client = llm_client
 
     def execute(self, request: GetInterviewResultRequest) -> GetInterviewResultResponse:
+        """面接結果を取得する
+
+        Args:
+            request (GetInterviewResultRequest): 面接結果を取得するリクエスト
+
+        Returns:
+            GetInterviewResultResponse: 面接結果を取得した結果
+        """
         # FIXME: 質問IDが連番であることを仮定している
         first_question = self.interview_repository.get_question(
             request.interview_id,

--- a/backend/app/usecase/usecases/get_interview_result_usecase.py
+++ b/backend/app/usecase/usecases/get_interview_result_usecase.py
@@ -1,0 +1,51 @@
+from app.domain.llm_clients.llm_client import LLMClient
+from app.domain.repositories.interview_repository import InterviewRepository
+from app.schemas.interview_schema import (
+    GetInterviewResultRequest,
+    GetInterviewResultResponse,
+)
+
+
+class GetInterviewResultUseCase:
+    first_question_id = 1
+
+    def __init__(
+        self,
+        interview_repository: InterviewRepository,
+        llm_client: LLMClient,
+    ):
+        self.interview_repository = interview_repository
+        self.llm_client = llm_client
+
+    def execute(self, request: GetInterviewResultRequest) -> GetInterviewResultResponse:
+        # FIXME: 質問IDが連番であることを仮定している
+        first_question = self.interview_repository.get_question(
+            request.interview_id,
+            str(self.first_question_id),
+        )
+
+        difficulty = first_question.difficulty
+        scores = [first_question.score]
+        chat_histories = [first_question.chat_history]
+
+        for question_id in range(
+            self.first_question_id + 1,
+            first_question.total_question + 1,
+        ):
+            question = self.interview_repository.get_question(
+                request.interview_id,
+                str(question_id),
+            )
+            scores.append(question.score)
+            chat_histories.append(question.chat_history)
+
+        general_review = self.llm_client.generate_general_review(
+            difficulty,
+            chat_histories,
+        )
+
+        return GetInterviewResultResponse(
+            interview_id=request.interview_id,
+            scores=scores,
+            general_review=general_review,
+        )

--- a/backend/app/usecase/usecases/get_interview_result_usecase.py
+++ b/backend/app/usecase/usecases/get_interview_result_usecase.py
@@ -42,7 +42,7 @@ class GetInterviewResultUseCase:
         scores = [question.score for question in questions]
         chat_histories = [question.chat_history for question in questions]
 
-        general_review = self.llm_client.generate_general_review(
+        overall_review = self.llm_client.generate_general_review(
             difficulty,
             chat_histories,
         )
@@ -50,5 +50,5 @@ class GetInterviewResultUseCase:
         return GetInterviewResultResponse(
             interview_id=request.interview_id,
             scores=scores,
-            general_review=general_review,
+            overall_review=overall_review,
         )

--- a/backend/app/usecase/usecases/get_interview_result_usecase.py
+++ b/backend/app/usecase/usecases/get_interview_result_usecase.py
@@ -7,8 +7,6 @@ from app.schemas.interview_schema import (
 
 
 class GetInterviewResultUseCase:
-    first_question_id = 1
-
     def __init__(
         self,
         interview_repository: InterviewRepository,
@@ -31,27 +29,18 @@ class GetInterviewResultUseCase:
 
         Returns:
             GetInterviewResultResponse: 面接結果を取得した結果
+
+        Raises:
+            Exception: 面接結果が存在しない場合
         """
-        # FIXME: 質問IDが連番であることを仮定している
-        first_question = self.interview_repository.get_question(
-            request.interview_id,
-            str(self.first_question_id),
-        )
+        questions = self.interview_repository.get_all_questions(request.interview_id)
 
-        difficulty = first_question.difficulty
-        scores = [first_question.score]
-        chat_histories = [first_question.chat_history]
+        if len(questions) == 0:
+            raise Exception("面接結果が存在しません")
 
-        for question_id in range(
-            self.first_question_id + 1,
-            first_question.total_question + 1,
-        ):
-            question = self.interview_repository.get_question(
-                request.interview_id,
-                str(question_id),
-            )
-            scores.append(question.score)
-            chat_histories.append(question.chat_history)
+        difficulty = questions[0].difficulty
+        scores = [question.score for question in questions]
+        chat_histories = [question.chat_history for question in questions]
 
         general_review = self.llm_client.generate_general_review(
             difficulty,

--- a/backend/tests/usecase/usecases/test_get_interview_result_usecase.py
+++ b/backend/tests/usecase/usecases/test_get_interview_result_usecase.py
@@ -44,7 +44,7 @@ def test_execute_success(
         )
         for i in range(1, total_question + 1)
     ]
-    mock_interview_repository.get_question.side_effect = questions
+    mock_interview_repository.get_all_questions.return_value = questions
     mock_llm_client.generate_general_review.return_value = general_review
 
     # リクエストの準備
@@ -59,7 +59,7 @@ def test_execute_success(
     assert response.general_review == general_review
 
     # リポジトリの呼び出し確認
-    assert mock_interview_repository.get_question.call_count == total_question
+    assert mock_interview_repository.get_all_questions.call_count == 1
 
     # LLMクライアントの呼び出し確認
     mock_llm_client.generate_general_review.assert_called_once_with(
@@ -74,7 +74,7 @@ def test_execute_failure_when_interview_not_found(
     mock_llm_client: LLMClient,
 ):
     # モックの設定
-    mock_interview_repository.get_question.side_effect = Exception()
+    mock_interview_repository.get_all_questions.side_effect = Exception()
 
     # リクエストの準備
     request = GetInterviewResultRequest(interview_id=interview_id)
@@ -84,7 +84,7 @@ def test_execute_failure_when_interview_not_found(
         get_interview_result_usecase.execute(request)
 
     # リポジトリの呼び出し確認
-    mock_interview_repository.get_question.assert_called_once()
+    mock_interview_repository.get_all_questions.assert_called_once()
     mock_llm_client.generate_general_review.assert_not_called()
 
 
@@ -105,7 +105,7 @@ def test_execute_failure_when_general_review_generation_fails(
         )
         for i in range(1, total_question + 1)
     ]
-    mock_interview_repository.get_question.side_effect = questions
+    mock_interview_repository.get_all_questions.return_value = questions
     mock_llm_client.generate_general_review.side_effect = Exception()
 
     # リクエストの準備
@@ -116,7 +116,7 @@ def test_execute_failure_when_general_review_generation_fails(
         get_interview_result_usecase.execute(request)
 
     # リポジトリの呼び出し確認
-    assert mock_interview_repository.get_question.call_count == total_question
+    assert mock_interview_repository.get_all_questions.call_count == 1
 
     # LLMクライアントの呼び出し確認
     mock_llm_client.generate_general_review.assert_called_once_with(

--- a/backend/tests/usecase/usecases/test_get_interview_result_usecase.py
+++ b/backend/tests/usecase/usecases/test_get_interview_result_usecase.py
@@ -1,0 +1,125 @@
+import random
+
+import pytest
+from app.domain.entities.chat_history import ChatHistory
+from app.domain.entities.difficulty import Difficulty
+from app.domain.entities.interview_question import InterviewQuestion
+from app.domain.llm_clients.llm_client import LLMClient
+from app.domain.repositories.interview_repository import InterviewRepository
+from app.schemas.interview_schema import GetInterviewResultRequest
+from app.usecase.usecases.get_interview_result_usecase import GetInterviewResultUseCase
+
+# テストデータ
+interview_id = "b5d0d93a-737b-4f90-81dc-bb58a2cba892"
+total_question = 4
+max_score = 100 // total_question
+general_review = "総評"
+
+
+@pytest.fixture
+def get_interview_result_usecase(
+    mock_interview_repository,
+    mock_llm_client,
+) -> GetInterviewResultUseCase:
+    return GetInterviewResultUseCase(
+        interview_repository=mock_interview_repository,
+        llm_client=mock_llm_client,
+    )
+
+
+def test_execute_success(
+    get_interview_result_usecase: GetInterviewResultUseCase,
+    mock_interview_repository: InterviewRepository,
+    mock_llm_client: LLMClient,
+):
+    # モックの設定
+    questions = [
+        InterviewQuestion(
+            interview_id=interview_id,
+            question_id=str(i),
+            difficulty=Difficulty.normal,
+            total_question=total_question,
+            chat_history=ChatHistory(),
+            score=random.randint(0, max_score),
+        )
+        for i in range(1, total_question + 1)
+    ]
+    mock_interview_repository.get_question.side_effect = questions
+    mock_llm_client.generate_general_review.return_value = general_review
+
+    # リクエストの準備
+    request = GetInterviewResultRequest(interview_id=interview_id)
+
+    # テスト実行
+    response = get_interview_result_usecase.execute(request)
+
+    # 戻り値の検証
+    assert response.interview_id == interview_id
+    assert len(response.scores) == total_question
+    assert response.general_review == general_review
+
+    # リポジトリの呼び出し確認
+    assert mock_interview_repository.get_question.call_count == total_question
+
+    # LLMクライアントの呼び出し確認
+    mock_llm_client.generate_general_review.assert_called_once_with(
+        Difficulty.normal,
+        [question.chat_history for question in questions],
+    )
+
+
+def test_execute_failure_when_interview_not_found(
+    get_interview_result_usecase: GetInterviewResultUseCase,
+    mock_interview_repository: InterviewRepository,
+    mock_llm_client: LLMClient,
+):
+    # モックの設定
+    mock_interview_repository.get_question.side_effect = Exception()
+
+    # リクエストの準備
+    request = GetInterviewResultRequest(interview_id=interview_id)
+
+    # テスト実行と例外の検証
+    with pytest.raises(Exception):
+        get_interview_result_usecase.execute(request)
+
+    # リポジトリの呼び出し確認
+    mock_interview_repository.get_question.assert_called_once()
+    mock_llm_client.generate_general_review.assert_not_called()
+
+
+def test_execute_failure_when_general_review_generation_fails(
+    get_interview_result_usecase: GetInterviewResultUseCase,
+    mock_interview_repository: InterviewRepository,
+    mock_llm_client: LLMClient,
+):
+    # モックの設定
+    questions = [
+        InterviewQuestion(
+            interview_id=interview_id,
+            question_id=str(i),
+            difficulty=Difficulty.normal,
+            total_question=total_question,
+            chat_history=ChatHistory(),
+            score=random.randint(0, max_score),
+        )
+        for i in range(1, total_question + 1)
+    ]
+    mock_interview_repository.get_question.side_effect = questions
+    mock_llm_client.generate_general_review.side_effect = Exception()
+
+    # リクエストの準備
+    request = GetInterviewResultRequest(interview_id=interview_id)
+
+    # テスト実行と例外の検証
+    with pytest.raises(Exception):
+        get_interview_result_usecase.execute(request)
+
+    # リポジトリの呼び出し確認
+    assert mock_interview_repository.get_question.call_count == total_question
+
+    # LLMクライアントの呼び出し確認
+    mock_llm_client.generate_general_review.assert_called_once_with(
+        Difficulty.normal,
+        [question.chat_history for question in questions],
+    )

--- a/backend/tests/usecase/usecases/test_get_interview_result_usecase.py
+++ b/backend/tests/usecase/usecases/test_get_interview_result_usecase.py
@@ -13,7 +13,7 @@ from app.usecase.usecases.get_interview_result_usecase import GetInterviewResult
 interview_id = "b5d0d93a-737b-4f90-81dc-bb58a2cba892"
 total_question = 4
 max_score = 100 // total_question
-general_review = "総評"
+overall_review = "総評"
 
 
 @pytest.fixture
@@ -45,7 +45,7 @@ def test_execute_success(
         for i in range(1, total_question + 1)
     ]
     mock_interview_repository.get_all_questions.return_value = questions
-    mock_llm_client.generate_general_review.return_value = general_review
+    mock_llm_client.generate_general_review.return_value = overall_review
 
     # リクエストの準備
     request = GetInterviewResultRequest(interview_id=interview_id)
@@ -56,7 +56,7 @@ def test_execute_success(
     # 戻り値の検証
     assert response.interview_id == interview_id
     assert len(response.scores) == total_question
-    assert response.general_review == general_review
+    assert response.overall_review == overall_review
 
     # リポジトリの呼び出し確認
     assert mock_interview_repository.get_all_questions.call_count == 1


### PR DESCRIPTION
## Issue

- Close #132 

## やったこと

- タイトル参照
- ユースケースの入出力となるスキーマを定義した
- ユースケースのテストコードを書いた

## 動作確認

```
======================================================================= test session starts ========================================================================
platform darwin -- Python 3.12.0, pytest-8.4.0, pluggy-1.6.0
rootdir: /Users/shunsei/workspace/project/hackathon/repo-interviewer/backend
configfile: pyproject.toml
plugins: anyio-4.9.0
collected 17 items                                                                                                                                                 

domain/entities/test_chat_history.py .                                                                                                                       [  5%]
usecase/usecases/test_get_feedback_usecase.py ......                                                                                                         [ 41%]
usecase/usecases/test_get_interview_result_usecase.py ...                                                                                                    [ 58%]
usecase/usecases/test_get_question_usecase.py ...                                                                                                            [ 76%]
usecase/usecases/test_set_up_interview_usecase.py ....                                                                                                       [100%]

======================================================================== 17 passed in 0.36s ========================================================================
```