### PR TITLE
フィードバックを生成するrouterを実装した

### DIFF
--- a/backend/app/api/dependencies.py
+++ b/backend/app/api/dependencies.py
@@ -10,6 +10,7 @@ from app.infrastructure.repositories.local.source_code_repository import (
 from app.infrastructure.repositories.redis.interview_repository import (
     RedisInterviewRepository,
 )
+from app.usecase.usecases.get_feedback_usecase import GetFeedbackUseCase
 from app.usecase.usecases.setup_interview_usecase import SetUpInterviewUseCase
 from fastapi import Depends
 
@@ -32,6 +33,19 @@ def get_set_up_interview_usecase(
     llm_client: LLMClient = Depends(get_llm_client),
 ) -> SetUpInterviewUseCase:
     return SetUpInterviewUseCase(
+        interview_repository=interview_repository,
+        source_code_repository=source_code_repository,
+        llm_client=llm_client,
+        source_code_dir=Path("tmp"),
+    )
+
+
+def get_feedback_usecase(
+    interview_repository: InterviewRepository = Depends(get_interview_repository),
+    source_code_repository: SourceCodeRepository = Depends(get_source_code_repository),
+    llm_client: LLMClient = Depends(get_llm_client),
+) -> GetFeedbackUseCase:
+    return GetFeedbackUseCase(
         interview_repository=interview_repository,
         source_code_repository=source_code_repository,
         llm_client=llm_client,

--- a/backend/app/api/routers/interview.py
+++ b/backend/app/api/routers/interview.py
@@ -1,10 +1,7 @@
-from typing import Union
-
-from app.api.dependencies import get_set_up_interview_usecase
+from app.api.dependencies import get_feedback_usecase, get_set_up_interview_usecase
 from app.domain.entities.difficulty import Difficulty
 from app.schemas.interview_schema import (
     InterviewInterviewIdGetResponse,
-    InterviewInterviewIdPostErrorResponse,
     InterviewInterviewIdPostRequest,
     InterviewInterviewIdPostResponse,
     InterviewInterviewIdResultGetErrorResponse,
@@ -13,12 +10,13 @@ from app.schemas.interview_schema import (
 from app.services.interview_service import (
     get_interview_result,
     get_question,
-    get_response,
 )
 from app.usecase.dtos.interview_dto import (
+    GetFeedbackRequest,
     SetUpInterviewRequest,
     SetUpInterviewResponse,
 )
+from app.usecase.usecases.get_feedback_usecase import GetFeedbackUseCase
 from app.usecase.usecases.setup_interview_usecase import SetUpInterviewUseCase
 from fastapi import APIRouter, Depends, Form, HTTPException, UploadFile, status
 
@@ -61,38 +59,37 @@ async def set_up_interview(
 @router.post(
     "/{interview_id}",
     response_model=InterviewInterviewIdPostResponse,
-    responses={"500": {"model": InterviewInterviewIdPostErrorResponse}},
-    tags=["InterviewAPI"],
+    status_code=status.HTTP_200_OK,
+    tags=["Interview"],
+    summary="ユーザーの回答に対してフィードバックを返す",
+    operation_id="get_feedback",
 )
-def post_interview_interview_id(
+def get_feedback(
     interview_id: str,
     body: InterviewInterviewIdPostRequest,
-) -> Union[InterviewInterviewIdPostResponse, InterviewInterviewIdPostErrorResponse]:
+    usecase: GetFeedbackUseCase = Depends(get_feedback_usecase),
+):
     """
-    ユーザーの回答に対してLLMからの返答を取得
+    ユーザーの回答に対してフィードバックを返す
     """
     try:
-        request_body = InterviewInterviewIdPostRequest(
+        request_body = GetFeedbackRequest(
+            interview_id=interview_id,
             question_id=body.question_id,
             message=body.message,
         )
     except Exception as e:
-        return InterviewInterviewIdPostErrorResponse(
-            error_message=f"リクエストボディが不正です: {str(e)}"
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"リクエストボディが不正です: {str(e)}",
         )
 
-    score, comment, continue_question = get_response(interview_id, request_body)
-
-    if score == 0 and comment == "":
-        return InterviewInterviewIdPostErrorResponse(
-            error_message="応答の生成に失敗しました"
-        )
+    response = usecase.execute(request_body)
 
     return InterviewInterviewIdPostResponse(
-        question_id=request_body.question_id,
-        score=score,
-        response=comment,
-        continue_question=continue_question,
+        question_id=response.question_id,
+        score=response.score,
+        response=response.comment,
     )
 
 

--- a/backend/app/api/routers/interview.py
+++ b/backend/app/api/routers/interview.py
@@ -87,6 +87,7 @@ def get_feedback(
     response = usecase.execute(request_body)
 
     return InterviewInterviewIdPostResponse(
+        interview_id=response.interview_id,
         question_id=response.question_id,
         score=response.score,
         response=response.comment,

--- a/backend/app/schemas/interview_schema.py
+++ b/backend/app/schemas/interview_schema.py
@@ -32,12 +32,13 @@ class InterviewPostResponse(BaseModel):
 
 
 class InterviewInterviewIdPostRequest(BaseModel):
-    question_id: int
+    question_id: str
     message: str
 
 
 class InterviewInterviewIdPostResponse(BaseModel):
-    question_id: int
+    interview_id: str
+    question_id: str
     score: int = Field(ge=0, le=100)
     response: str
 

--- a/backend/app/schemas/interview_schema.py
+++ b/backend/app/schemas/interview_schema.py
@@ -40,9 +40,9 @@ class InterviewInterviewIdPostResponse(BaseModel):
     question_id: int
     score: int = Field(ge=0, le=100)
     response: str
-    continue_question: bool
 
 
+# TODO: リファクタリング後に削除する
 class InterviewInterviewIdPostErrorResponse(BaseModel):
     error_message: str
 

--- a/backend/test_api.py
+++ b/backend/test_api.py
@@ -72,7 +72,7 @@ class InterviewSession:
             "message": message,
         }
 
-        response = requests.post(url, headers=headers, data=request_body)
+        response = requests.post(url, headers=headers, json=request_body)
         print_result(response.status_code, 200, response.text)
 
     def get_current_question(self) -> None:

--- a/backend/tests/api/routers/interview/test_get_feedback.py
+++ b/backend/tests/api/routers/interview/test_get_feedback.py
@@ -1,0 +1,109 @@
+from unittest.mock import MagicMock
+
+import pytest
+from app.api.dependencies import get_feedback_usecase
+from app.usecase.dtos.interview_dto import (
+    GetFeedbackRequest,
+    GetFeedbackResponse,
+)
+from app.usecase.usecases.get_feedback_usecase import GetFeedbackUseCase
+from fastapi import status
+from fastapi.testclient import TestClient
+from main import app
+
+# テストデータ
+interview_id = "70da67e2-899c-44fd-8c0b-491decaecb65"
+question_id = "1"
+message = "テスト回答"
+score = 80
+comment = "良い回答です"
+
+
+@pytest.fixture
+def mock_get_feedback_usecase():
+    mock_usecase = MagicMock(spec=GetFeedbackUseCase)
+    app.dependency_overrides[get_feedback_usecase] = lambda: mock_usecase
+    return mock_usecase
+
+
+def test_get_feedback_success(
+    client: TestClient,
+    mock_get_feedback_usecase: GetFeedbackUseCase,
+):
+    expected_response = GetFeedbackResponse(
+        interview_id=interview_id,
+        question_id=question_id,
+        score=score,
+        comment=comment,
+    )
+    mock_get_feedback_usecase.execute.return_value = expected_response
+
+    request_body = {
+        "question_id": question_id,
+        "message": message,
+    }
+
+    actual_response = client.post(
+        f"/interview/{interview_id}",
+        json=request_body,
+    )
+    assert actual_response.status_code == status.HTTP_200_OK
+
+    response_body = actual_response.json()
+    assert response_body["question_id"] == question_id
+    assert response_body["score"] == score
+    assert response_body["response"] == comment
+
+    mock_get_feedback_usecase.execute.assert_called_once_with(
+        GetFeedbackRequest(
+            interview_id=interview_id,
+            question_id=question_id,
+            message=message,
+        )
+    )
+
+
+def test_get_feedback_missing_question_id(client: TestClient):
+    request_body = {
+        "message": message,
+    }
+
+    response = client.post(
+        f"/interview/{interview_id}",
+        json=request_body,
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_get_feedback_missing_message(client: TestClient):
+    request_body = {
+        "question_id": question_id,
+    }
+
+    response = client.post(
+        f"/interview/{interview_id}",
+        json=request_body,
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_get_feedback_use_case_raises_exception(
+    client: TestClient,
+    mock_get_feedback_usecase: GetFeedbackUseCase,
+):
+    mock_get_feedback_usecase.execute.side_effect = Exception()
+
+    request_body = {
+        "question_id": question_id,
+        "message": message,
+    }
+
+    with pytest.raises(Exception):
+        client.post(
+            f"/interview/{interview_id}",
+            json=request_body,
+        )
+
+    mock_get_feedback_usecase.execute.assert_called_once()


### PR DESCRIPTION
## Issue

- Close #143

## やったこと

- タイトル参照
- 実装したrouterのテストコードを書いた

## 動作確認

```sh
RepoInterviewer API Test CLI
--------------------------------
1. POST /interview
2. POST /interview/:interview_id
3. GET /interview/:interview_id?question_id=now
4. GET /interview/:interview_id?question_id=next
5. GET /interview/:interview_id/result
6. Exit

Select a test to run (1-6): 2    
Enter your answer: 書きやすい
Testing POST /interview/:interview_id
Status: 200 ✅ Passed
Response: {"question_id":1,"score":30,"response":"書きやすいのはマジでかいよね！f文字列は直感的に書けるから、コードもスッキリするじゃん☆ でも、複雑なロジックを埋め込むのはちょいムズかも。あと、他の文字列結合方法より、パフォーマンスがちょっとだけ遅い場合もあるらしいよ！でも、今回のケースだと全然気にしなくてOK！"}
```

```sh
================================================================ test session starts =================================================================
platform darwin -- Python 3.12.0, pytest-8.4.0, pluggy-1.6.0
rootdir: /Users/shunsei/workspace/project/hackathon/repo-interviewer/backend
configfile: pyproject.toml
plugins: anyio-4.9.0
collected 26 items                                                                                                                                   

api/routers/interview/test_get_feedback.py ....                                                                                                [ 15%]
api/routers/interview/test_set_up_interview.py .....                                                                                           [ 34%]
domain/entities/test_chat_history.py .                                                                                                         [ 38%]
usecase/usecases/test_get_feedback_usecase.py ......                                                                                           [ 61%]
usecase/usecases/test_get_interview_result_usecase.py ...                                                                                      [ 73%]
usecase/usecases/test_get_question_usecase.py ...                                                                                              [ 84%]
usecase/usecases/test_set_up_interview_usecase.py ....                                                                                         [100%]

================================================================= 26 passed in 0.57s =================================================================
```