### PR TITLE
拡張機能を起動したときにタイトル未定のファイルが開かれないようにする

### DIFF
--- a/frontend/src/commands/extension.ts
+++ b/frontend/src/commands/extension.ts
@@ -1,9 +1,9 @@
-import * as vscode from "vscode";
 import type { VscodeApiRequestValue } from "@shared/vscode-api-request-value";
-import { handleWebviewMessage } from "./functions/handle-webview-message";
+import * as vscode from "vscode";
 import { getWebviewUris } from "./functions/get-webview-uris";
-import { getNonce } from "./utilities/get-nonce";
+import { handleWebviewMessage } from "./functions/handle-webview-message";
 import { openWindow } from "./functions/open-webview";
+import { getNonce } from "./utilities/get-nonce";
 
 // 拡張機能起動時のエントリポイント
 export function activate(context: vscode.ExtensionContext) {

--- a/frontend/src/commands/functions/open-webview.ts
+++ b/frontend/src/commands/functions/open-webview.ts
@@ -6,9 +6,11 @@ let currentPanel: vscode.WebviewPanel | undefined;
 export async function openWindow(
   extensionUri: vscode.Uri
 ): Promise<vscode.WebviewPanel> {
-  await vscode.commands.executeCommand(
-    "workbench.action.files.newUntitledFile"
-  );
+  if (vscode.window.visibleTextEditors.length === 0) {
+    await vscode.commands.executeCommand(
+      "workbench.action.openWalkthrough"
+    );
+  }
 
   if (currentPanel) {
     currentPanel.reveal();


### PR DESCRIPTION
## Issue

- Close #219

## 目的

毎回タイトル未定のファイルが開かれるのはウザイ

## やったこと

- ファイルが開かれてるときは何も開かない
- ファイルが開かれていない時「ようこそ」を開く

## 動作確認

けいすけに直接見せる
